### PR TITLE
Fix link to online demo in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples of use of ThebeLab
 
-You can [browse them online](https://minrk.github.io/thebelab/example/).
+You can [browse them online](https://minrk.github.io/thebelab/demo).
 To serve them locally instead, run:
 
     python -m http.server


### PR DESCRIPTION
Change link target from [0] which was "404 Not Found" to [1].

- [0] https://minrk.github.io/thebelab/examples/
- [1] https://minrk.github.io/thebelab/demo