### PR TITLE
Adds support for gitlab and git repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ A full config script with defaults:
     repo: "minrk/ligo-binder",
     ref: "master",
     binderUrl: "https://mybinder.org",
+    // select repository source (optional). Supports Github(default), Gitlab, and Git
+    repoProvider: "github",
   },
   
   // Options for requesting a kernel from the notebook server

--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -296,7 +296,7 @@ export function requestBinderKernel({ binderOptions, kernelOptions }) {
   });
 }
 
-export function requestBinder({ repo, ref = "master", binderUrl = null } = {}) {
+export function requestBinder({ repo, ref = "master", binderUrl = null, type = "" } = {}) {
   // request a server from Binder
   // returns a Promise that will resolve with a serverSettings dict
 
@@ -306,15 +306,44 @@ export function requestBinder({ repo, ref = "master", binderUrl = null } = {}) {
   console.log("binder url", binderUrl, defaults);
   binderUrl = binderUrl || defaults.binderUrl;
   ref = ref || defaults.ref;
+  let url;
 
-  // trim github.com from repo
-  repo = repo.replace(/^(https?:\/\/)?github.com\//, "");
-  // trim trailing or leading '/' on repo
-  repo = repo.replace(/(^\/)|(\/?$)/g, "");
-  // trailing / on binderUrl
-  binderUrl = binderUrl.replace(/(\/?$)/g, "");
+  if (type.toLowerCase() === "git") {
+    // trim trailing or leading '/' on repo
+    repo = repo.replace(/(^\/)|(\/?$)/g, "");
+    // trailing / on binderUrl
+    binderUrl = binderUrl.replace(/(\/?$)/g, "");
+    //add /.git if not present
+    if (!repo.endsWith("/.git")) {
+      repo += "/.git";
+      console.log("Added /.git to repo name");
+    }
+    //convert to URL acceptable string. Required for git
+    repo = encodeURIComponent(repo);
 
-  let url = binderUrl + "/build/gh/" + repo + "/" + ref;
+    url = binderUrl + "/build/git/" + repo + "/" + ref;
+  }
+  else if (type.toLowerCase() === "gitlab") {
+    // trim github.com from repo
+    // trim trailing or leading '/' on repo
+    repo = repo.replace(/(^\/)|(\/?$)/g, "");
+    // trailing / on binderUrl
+    binderUrl = binderUrl.replace(/(\/?$)/g, "");
+    //convert to URL acceptable string. Required for gitlab
+    repo = encodeURIComponent(repo);
+
+    url = binderUrl + "/build/gl/" + repo + "/" + ref;
+  }
+  else {
+    // trim github.com from repo
+    repo = repo.replace(/^(https?:\/\/)?github.com\//, "");
+    // trim trailing or leading '/' on repo
+    repo = repo.replace(/(^\/)|(\/?$)/g, "");
+    // trailing / on binderUrl
+    binderUrl = binderUrl.replace(/(\/?$)/g, "");
+
+    url = binderUrl + "/build/gh/" + repo + "/" + ref;
+  }
   console.log("Binder build URL", url);
   events.trigger("status", {
     status: "building",

--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -296,19 +296,22 @@ export function requestBinderKernel({ binderOptions, kernelOptions }) {
   });
 }
 
-export function requestBinder({ repo, ref = "master", binderUrl = null, type = "" } = {}) {
+export function requestBinder({ repo, ref = "master", binderUrl = null, repoProvider = "" } = {}) {
   // request a server from Binder
   // returns a Promise that will resolve with a serverSettings dict
 
   // populate from defaults
   let defaults = mergeOptions().binderOptions;
-  repo = repo || defaults.repo;
+  if (!repo) {
+    repo = defaults.repo;
+    repoProvider = "";
+  }
   console.log("binder url", binderUrl, defaults);
   binderUrl = binderUrl || defaults.binderUrl;
   ref = ref || defaults.ref;
   let url;
 
-  if (type.toLowerCase() === "git") {
+  if (repoProvider.toLowerCase() === "git") {
     // trim trailing or leading '/' on repo
     repo = repo.replace(/(^\/)|(\/?$)/g, "");
     // trailing / on binderUrl
@@ -323,8 +326,9 @@ export function requestBinder({ repo, ref = "master", binderUrl = null, type = "
 
     url = binderUrl + "/build/git/" + repo + "/" + ref;
   }
-  else if (type.toLowerCase() === "gitlab") {
-    // trim github.com from repo
+  else if (repoProvider.toLowerCase() === "gitlab") {
+    // trim gitlab.com from repo
+    repo = repo.replace(/^(https?:\/\/)?gitlab.com\//, "");
     // trim trailing or leading '/' on repo
     repo = repo.replace(/(^\/)|(\/?$)/g, "");
     // trailing / on binderUrl


### PR DESCRIPTION
Added a new optional binderOptions attribute "repoProvider" to specify an alternative provider such as gitlab or git.

Github is still the assumed default and this change does not affect existing installations.