### PR TITLE
Added option for codeMirrorConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ A full config script with defaults:
   //      // only apply the prompt stripping to cells matching this selector (optional)
   //      selector: '.sage-input',
   //    },
+  
+  // Additional options to pass to CodeMirror instances
+  codeMirrorConfig: {},
 }
 ```
 

--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -220,13 +220,15 @@ function renderCell(element, options) {
   Widget.attach(outputArea, theDiv);
 
   const mode = $element.data("language") || "python3";
-  let cm = new CodeMirror($cm_element[0], {
+  const required = {
     value: source,
     mode: mode,
     extraKeys: {
       "Shift-Enter": execute,
     },
-  });
+  };
+  let codeMirrorConfig = Object.assign(options.codeMirrorconfig,required);
+  let cm = new CodeMirror($cm_element[0], codeMirrorConfig);
   Mode.ensure(mode).then(modeSpec => {
     cm.setOption("mode", mode);
   });


### PR DESCRIPTION
Allows for passing through CodeMirror options specified here: [https://codemirror.net/doc/manual.html#config](https://codemirror.net/doc/manual.html#config)

Allows for enabling options such as readOnly, lineNumbers, and lineWrapping. Personally, I need all of these options for my use case.

closes #97 
