### PR TITLE
adding example html files to static_files so they show up

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,7 +104,7 @@ html_sidebars = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ["_static", "../examples"]
 
 # -- Options for HTMLHelp output ------------------------------------------
 
@@ -185,11 +185,3 @@ epub_exclude_files = ['search.html']
 
 # -- Linkcheck options ------------------
 linkcheck_anchors_ignore = ["/#!"]
-
-# -- Move the examples folder into the _build directory
-import os
-import shutil as sh
-os.makedirs('_build', exist_ok=True)
-if os.path.exists("_build/examples"):
-    sh.rmtree("_build/examples")
-sh.copytree("../examples", "_build/examples")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,12 +90,12 @@ For more examples showing how to configure, use, and activate Thebelab, see
 the list below. We recommend browsing the raw HTML of each one in order to
 see how Thebelab is used.
 
-* `Making use of Jupyter interactive widgets <examples/widgets.html>`_
-* `Status field and styling <examples/status_field.html>`_
-* `Activate/Status button <examples/activate_button.html>`_
-* `Alternative computational environments; code cells with prompts and outputs <examples/prompts.html>`_
-* `Using a local Jupyter server as kernel provider <examples/local.html>`_
-* `Setting predefined output for cells <examples/demo-preview.html>`_
+* `Making use of Jupyter interactive widgets <_static/widgets.html>`_
+* `Status field and styling <_static/status_field.html>`_
+* `Activate/Status button <_static/activate_button.html>`_
+* `Alternative computational environments; code cells with prompts and outputs <_static/prompts.html>`_
+* `Using a local Jupyter server as kernel provider <_static/local.html>`_
+* `Setting predefined output for cells <_static/demo-preview.html>`_
 * `ThebeLab in use for SageMath documentation <http://sage-package.readthedocs.io/en/latest/sage_package/sphinx-demo.html>`_
   (`about <http://sage-package.readthedocs.io/en/latest/sage_package/thebe.html>`_)
   Showcases a fancy activate button, and fetching thebe and running computations locally when possible. Relevant files:


### PR DESCRIPTION
ReadTheDocs currently doesn't have the example HTML files properly-linked, I think this will fix that. Gonna self merge since this is broken right now