### PR TITLE
Add ability to change path for binder

### DIFF
--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -7,7 +7,7 @@ if (typeof window !== "undefined") {
 }
 
 import { Widget } from "@phosphor/widgets";
-import { Session } from "@jupyterlab/services"
+import { Session } from "@jupyterlab/services";
 import { ServerConnection } from "@jupyterlab/services";
 import { MathJaxTypesetter } from "@jupyterlab/mathjax2";
 import { OutputArea, OutputAreaModel } from "@jupyterlab/outputarea";

--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -7,7 +7,7 @@ if (typeof window !== "undefined") {
 }
 
 import { Widget } from "@phosphor/widgets";
-import { Kernel } from "@jupyterlab/services";
+import { Session } from "@jupyterlab/services"
 import { ServerConnection } from "@jupyterlab/services";
 import { MathJaxTypesetter } from "@jupyterlab/mathjax2";
 import { OutputArea, OutputAreaModel } from "@jupyterlab/outputarea";

--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -304,13 +304,14 @@ export function requestKernel(kernelOptions) {
     status: "starting",
     message: "Starting Kernel",
   });
-  let p = Kernel.startNew(kernelOptions);
-  p.then(kernel => {
+  let p = Session.startNew(kernelOptions);
+  p.then(session => {
     events.trigger("status", {
       status: "ready",
       message: "Kernel is ready",
     });
-    return kernel;
+    let k = session.kernel;
+    return k;
   });
   return p;
 }
@@ -485,7 +486,8 @@ export function bootstrap(options) {
     });
   }
 
-  kernelPromise.then(kernel => {
+  kernelPromise.then(session => {
+    let kernel = session.kernel;
     // debug
     if (typeof window !== "undefined") window.thebeKernel = kernel;
     hookupKernel(kernel, cells);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
     // shim(/@jupyterlab\/codemirror\/lib\/editor/),
     shim(/@jupyterlab\/codeeditor\/lib\/jsoneditor/),
     shim(/@jupyterlab\/coreutils\/lib\/(time|settingregistry|.*menu.*)/),
-    shim(/@jupyterlab\/services\/lib\/(session|contents|terminal)\/.*/),
+    shim(/@jupyterlab\/services\/lib\/(contents|terminal)\/.*/),
     new Visualizer({
       filename: "../webpack.stats.html",
     }),


### PR DESCRIPTION
Change from `Kernel` to `Session` to support the `path` argument.
This adds the ability to specify `path` in `kernelOptions` so the current working directory is changed.

Fixes #114.