### PR TITLE
Remove / from .git suffix for binderUrl

### DIFF
--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -350,11 +350,6 @@ export function requestBinder({
     repo = repo.replace(/(^\/)|(\/?$)/g, "");
     // trailing / on binderUrl
     binderUrl = binderUrl.replace(/(\/?$)/g, "");
-    //add /.git if not present
-    if (!repo.endsWith(".git")) {
-      repo += ".git";
-      console.log("Added .git to repo name");
-    }
     //convert to URL acceptable string. Required for git
     repo = encodeURIComponent(repo);
 

--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -351,9 +351,9 @@ export function requestBinder({
     // trailing / on binderUrl
     binderUrl = binderUrl.replace(/(\/?$)/g, "");
     //add /.git if not present
-    if (!repo.endsWith("/.git")) {
-      repo += "/.git";
-      console.log("Added /.git to repo name");
+    if (!repo.endsWith(".git")) {
+      repo += ".git";
+      console.log("Added .git to repo name");
     }
     //convert to URL acceptable string. Required for git
     repo = encodeURIComponent(repo);


### PR DESCRIPTION
This PR removes the / from the .git suffix for the binderUrl. When including the `/` the repository is not recognized, for example by a privately hosted GitLab server.

Now the following config DOES work, while without this PR it does not:
```
binderOptions: {
      repoProvider: "git",
      repo: "https://gitlab.example.com/user/repo",
      ref: "e6c970126f4e819e4a3eb717a86ba9fb5237fde3",
    }
```
