### PR TITLE
Drop cssnext bundle

### DIFF
--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -25,7 +25,7 @@ import { requireLoader } from "@jupyter-widgets/html-manager";
 import { Mode } from "@jupyterlab/codemirror";
 
 import "@jupyterlab/theme-light-extension/static/index.css";
-import "@jupyter-widgets/controls/css/widgets.built.css";
+import "@jupyter-widgets/controls/css/widgets-base.css";
 import "./index.css";
 
 // Exposing @jupyter-widgets/base and @jupyter-widgets/controls as amd


### PR DESCRIPTION
`widgets.built.css` is the CSS of `@jupyter-widgets/controls` bundled with cssnext, which includes the polyfill for jupyterlab CSS variables (which we use for the classic notebook) and substitutes them by their values in all of the widgets CSS.

This PR makes thebelab use directly the bare CSS making use of the CSS variables that are already on the page in thebelab.

- Note that the tool that was used for this substitution was cssnext which is now deprecated.
- We still produce the old `widgets.built.css` in `@jupyter-widgets/controls` for backward compatibility.

