### PR TITLE
Fixup html-manager version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -695,23 +695,6 @@
         "semver": "^5.3.0"
       }
     },
-    "@babel/runtime": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
-      "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-          "dev": true
-        }
-      }
-    },
     "@babel/template": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
@@ -751,45 +734,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@blueprintjs/core": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.15.1.tgz",
-      "integrity": "sha512-M8ltbqqlMZuZ6SEuqo/3Fr59ZcUfd8Er7ocbm7EACVfRW7dRhOCd/TKkf2kfICNtCDwznwXk0iAePLXZhUGtQg==",
-      "dev": true,
-      "requires": {
-        "@blueprintjs/icons": "^3.8.0",
-        "@types/dom4": "^2.0.1",
-        "classnames": "^2.2",
-        "dom4": "^2.0.1",
-        "normalize.css": "^8.0.0",
-        "popper.js": "^1.14.1",
-        "react-popper": "^1.0.0",
-        "react-transition-group": "^2.2.1",
-        "resize-observer-polyfill": "^1.5.0",
-        "tslib": "^1.9.0"
-      }
-    },
-    "@blueprintjs/icons": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.8.0.tgz",
-      "integrity": "sha512-yHaRQ3vfV9Gf3foZ4ONtxddz+u5ufkHqHj8Ia5VhPbFgG4el+cPdmsGGIIM72rgKS1KQa5Ay+ggjpByUlXvrKg==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.2",
-        "tslib": "^1.9.0"
-      }
-    },
-    "@blueprintjs/select": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.8.0.tgz",
-      "integrity": "sha512-sWWGZx/nARtxKfoFODlEQxA7HDpddGDC4uKPNMd1ZQgKazEtMkw0rFVm550K6Aoj0wp82TqqmcxHrb0VL6Epiw==",
-      "dev": true,
-      "requires": {
-        "@blueprintjs/core": "^3.15.0",
-        "classnames": "^2.2",
-        "tslib": "^1.9.0"
-      }
-    },
     "@jupyter-widgets/base": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@jupyter-widgets/base/-/base-1.2.3.tgz",
@@ -827,290 +771,24 @@
       }
     },
     "@jupyter-widgets/html-manager": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jupyter-widgets/html-manager/-/html-manager-0.16.1.tgz",
-      "integrity": "sha512-W/C5xut+XMSM6aRf2m0lpG6C2eErQCwZwhn3j+zWp070a56msS1b4hL23G63y4pz78zeoOEWzsIWMFTOghvCBg==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@jupyter-widgets/html-manager/-/html-manager-0.15.2.tgz",
+      "integrity": "sha512-HD16kSfl5HW6w0Bn9spclqYLw7CnZMeoRnWYmsvc9W+2lISrADWqpWHmla2qpBdZNgjA+TEmGzV688LAEzPMIQ==",
       "dev": true,
       "requires": {
-        "@jupyter-widgets/base": "^1.2.4",
-        "@jupyter-widgets/controls": "^1.4.4",
-        "@jupyter-widgets/output": "^1.1.4",
-        "@jupyter-widgets/schema": "^0.3.7",
-        "@jupyterlab/outputarea": "1.0.0-alpha.3 || 1.0.0-alpha.6",
-        "@jupyterlab/rendermime": "1.0.0-alpha.3 || 1.0.0-alpha.6",
-        "@jupyterlab/rendermime-interfaces": "1.3.0-alpha.3 || 1.3.0-alpha.6",
+        "@jupyter-widgets/base": "^1.2.2",
+        "@jupyter-widgets/controls": "^1.4.2",
+        "@jupyter-widgets/output": "^1.1.2",
+        "@jupyter-widgets/schema": "^0.3.6",
+        "@jupyterlab/outputarea": "^0.19.1",
+        "@jupyterlab/rendermime": "^0.19.1",
+        "@jupyterlab/rendermime-interfaces": "^1.1.0",
         "@phosphor/widgets": "^1.6.0",
         "ajv": "^5.2.2",
         "font-awesome": "^4.7.0",
         "jquery": "^3.1.1"
       },
       "dependencies": {
-        "@jupyter-widgets/base": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@jupyter-widgets/base/-/base-1.2.4.tgz",
-          "integrity": "sha512-PKJUsy5hTC5DtqWXK4IRKo0C9qqco/bXqOxZgzbh8b0D+TKTrjaRa4ctR3W7N1Tw/l4Al6xbiuPh4nywkaadCw==",
-          "dev": true,
-          "requires": {
-            "@jupyterlab/services": "^1.0.1 || ^2.0.0 || ^3.0.0 || 4.0.0-alpha.3 || 4.0.0-alpha.6",
-            "@phosphor/coreutils": "^1.2.0",
-            "@phosphor/messaging": "^1.2.1",
-            "@phosphor/widgets": "^1.3.0",
-            "@types/backbone": "^1.3.33",
-            "@types/lodash": "^4.14.66",
-            "backbone": "1.2.3",
-            "base64-js": "^1.2.1",
-            "jquery": "^3.1.1",
-            "lodash": "^4.17.4"
-          }
-        },
-        "@jupyter-widgets/controls": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/@jupyter-widgets/controls/-/controls-1.4.4.tgz",
-          "integrity": "sha512-wgeKBUVzSDUcQt1Z5zpEURO52fLS0q7h+y/3tC1YuKN38pbb5sPGj/In+Ihb988AQIDVPf+jyOEc3kVxFPYZEg==",
-          "dev": true,
-          "requires": {
-            "@jupyter-widgets/base": "^1.2.4",
-            "@phosphor/algorithm": "^1.1.0",
-            "@phosphor/domutils": "^1.1.0",
-            "@phosphor/messaging": "^1.2.1",
-            "@phosphor/signaling": "^1.2.0",
-            "@phosphor/widgets": "^1.3.0",
-            "d3-format": "^1.3.0",
-            "jquery": "^3.1.1",
-            "jquery-ui": "^1.12.1",
-            "underscore": "^1.8.3"
-          }
-        },
-        "@jupyter-widgets/output": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/@jupyter-widgets/output/-/output-1.1.4.tgz",
-          "integrity": "sha512-kwLznPiYymS7Vzc4Q9h/wAcCb1bp44snVO7TNTYYfPu3HVd/V2igAf22b23dxDMN5tA9LuWGlXmsHxvYBVxcow==",
-          "dev": true,
-          "requires": {
-            "@jupyter-widgets/base": "^1.2.4"
-          }
-        },
-        "@jupyterlab/apputils": {
-          "version": "1.0.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.0.0-alpha.6.tgz",
-          "integrity": "sha512-Ir7LHfXl/kcFiXmGWGayaMXShyi8WkLa9pRAUJYuRYcGbhJwvpKwGpaakrFr021UGFWJtem8mTTSAJ7s3OyOlA==",
-          "dev": true,
-          "requires": {
-            "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-            "@jupyterlab/services": "^4.0.0-alpha.6",
-            "@jupyterlab/ui-components": "^1.0.0-alpha.6",
-            "@phosphor/algorithm": "^1.1.2",
-            "@phosphor/commands": "^1.6.1",
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/disposable": "^1.1.2",
-            "@phosphor/domutils": "^1.1.2",
-            "@phosphor/messaging": "^1.2.2",
-            "@phosphor/properties": "^1.1.2",
-            "@phosphor/signaling": "^1.2.2",
-            "@phosphor/virtualdom": "^1.1.2",
-            "@phosphor/widgets": "^1.6.0",
-            "@types/react": "~16.8.8",
-            "react": "~16.8.4",
-            "react-dom": "~16.8.4",
-            "sanitize-html": "~1.18.2"
-          },
-          "dependencies": {
-            "@jupyterlab/services": {
-              "version": "4.0.0-alpha.6",
-              "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.0.0-alpha.6.tgz",
-              "integrity": "sha512-veLHmuPFMVt4ByLAks3+7GVpk3zMcBmBfUt2RiswHfeBhzGgSVEOq/Tovt59DUQ9wgBsYCUsrbBjrHHr/0jyZg==",
-              "dev": true,
-              "requires": {
-                "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-                "@jupyterlab/observables": "^2.2.0-alpha.6",
-                "@phosphor/algorithm": "^1.1.2",
-                "@phosphor/coreutils": "^1.3.0",
-                "@phosphor/disposable": "^1.1.2",
-                "@phosphor/signaling": "^1.2.2",
-                "node-fetch": "~2.2.0",
-                "ws": "~6.0.0"
-              }
-            }
-          }
-        },
-        "@jupyterlab/codeeditor": {
-          "version": "1.0.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.0.0-alpha.6.tgz",
-          "integrity": "sha512-6Y1m7s/CAEni/C+cWHToIbAsuCzahgBCtEqhrtnoHBD/LQvZ45RYuvIfhCAyEmT/ObQr1EN9gfmBkVnqzvnjXQ==",
-          "dev": true,
-          "requires": {
-            "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-            "@jupyterlab/observables": "^2.2.0-alpha.6",
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/disposable": "^1.1.2",
-            "@phosphor/dragdrop": "^1.3.0",
-            "@phosphor/messaging": "^1.2.2",
-            "@phosphor/signaling": "^1.2.2",
-            "@phosphor/widgets": "^1.6.0"
-          }
-        },
-        "@jupyterlab/codemirror": {
-          "version": "1.0.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-1.0.0-alpha.6.tgz",
-          "integrity": "sha512-fV5xh2GwnIDZyilIeTD2FCpwKLMLPOAR1k3gopBudh9UVk8KiGjjKth49fQyZfApSoVDZADgEDmvsWTmOh4JBA==",
-          "dev": true,
-          "requires": {
-            "@jupyterlab/apputils": "^1.0.0-alpha.6",
-            "@jupyterlab/codeeditor": "^1.0.0-alpha.6",
-            "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-            "@jupyterlab/observables": "^2.2.0-alpha.6",
-            "@jupyterlab/statusbar": "^1.0.0-alpha.6",
-            "@phosphor/algorithm": "^1.1.2",
-            "@phosphor/commands": "^1.6.1",
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/disposable": "^1.1.2",
-            "@phosphor/signaling": "^1.2.2",
-            "@phosphor/widgets": "^1.6.0",
-            "codemirror": "~5.42.0",
-            "react": "~16.8.4"
-          }
-        },
-        "@jupyterlab/coreutils": {
-          "version": "3.0.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.0.0-alpha.6.tgz",
-          "integrity": "sha512-t3Lp9iFRjzTsc573+KGKStE/YvkUbKQ2+7FF0hz9fDkeWp6+ZNCHWD97eudo6V+I/g5zRgO8eqgbjeKhGyv/KA==",
-          "dev": true,
-          "requires": {
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/disposable": "^1.1.2",
-            "@phosphor/signaling": "^1.2.2",
-            "ajv": "^6.5.5",
-            "comment-json": "^1.1.3",
-            "minimist": "~1.2.0",
-            "moment": "~2.21.0",
-            "path-posix": "~1.0.0",
-            "url-parse": "~1.4.3"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "6.10.0",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-              "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-              "dev": true,
-              "requires": {
-                "fast-deep-equal": "^2.0.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-              }
-            }
-          }
-        },
-        "@jupyterlab/observables": {
-          "version": "2.2.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.2.0-alpha.6.tgz",
-          "integrity": "sha512-u93u/knpD3Lijye3jlu3xfyZotcreFhQloZ+1iKRSXmDFwNvkjJqwTd9ibq9v1fcfGDcy+AiE50+7RqDxQ9YAQ==",
-          "dev": true,
-          "requires": {
-            "@phosphor/algorithm": "^1.1.2",
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/disposable": "^1.1.2",
-            "@phosphor/messaging": "^1.2.2",
-            "@phosphor/signaling": "^1.2.2"
-          }
-        },
-        "@jupyterlab/outputarea": {
-          "version": "1.0.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/outputarea/-/outputarea-1.0.0-alpha.6.tgz",
-          "integrity": "sha512-H4hkKAaXNL/WUX5DxsuhbC+cSodPkrYO35t66PjeyJMfezA8MP0bz9pdoDcJ5aOOvem/HEm48r4cuM4MEErtxg==",
-          "dev": true,
-          "requires": {
-            "@jupyterlab/apputils": "^1.0.0-alpha.6",
-            "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-            "@jupyterlab/observables": "^2.2.0-alpha.6",
-            "@jupyterlab/rendermime": "^1.0.0-alpha.6",
-            "@jupyterlab/rendermime-interfaces": "^1.3.0-alpha.6",
-            "@jupyterlab/services": "^4.0.0-alpha.6",
-            "@phosphor/algorithm": "^1.1.2",
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/disposable": "^1.1.2",
-            "@phosphor/messaging": "^1.2.2",
-            "@phosphor/signaling": "^1.2.2",
-            "@phosphor/widgets": "^1.6.0"
-          },
-          "dependencies": {
-            "@jupyterlab/services": {
-              "version": "4.0.0-alpha.6",
-              "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.0.0-alpha.6.tgz",
-              "integrity": "sha512-veLHmuPFMVt4ByLAks3+7GVpk3zMcBmBfUt2RiswHfeBhzGgSVEOq/Tovt59DUQ9wgBsYCUsrbBjrHHr/0jyZg==",
-              "dev": true,
-              "requires": {
-                "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-                "@jupyterlab/observables": "^2.2.0-alpha.6",
-                "@phosphor/algorithm": "^1.1.2",
-                "@phosphor/coreutils": "^1.3.0",
-                "@phosphor/disposable": "^1.1.2",
-                "@phosphor/signaling": "^1.2.2",
-                "node-fetch": "~2.2.0",
-                "ws": "~6.0.0"
-              }
-            }
-          }
-        },
-        "@jupyterlab/rendermime": {
-          "version": "1.0.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.0.0-alpha.6.tgz",
-          "integrity": "sha512-kiwxOEOumVyq+Hd5hX79olucd1uKswx6NjEmfAKi2bfneGEcP4Vd1a+X6pKT2Jqah7JBW0iEIprEsRUN6eOQFA==",
-          "dev": true,
-          "requires": {
-            "@jupyterlab/apputils": "^1.0.0-alpha.6",
-            "@jupyterlab/codemirror": "^1.0.0-alpha.6",
-            "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-            "@jupyterlab/observables": "^2.2.0-alpha.6",
-            "@jupyterlab/rendermime-interfaces": "^1.3.0-alpha.6",
-            "@jupyterlab/services": "^4.0.0-alpha.6",
-            "@phosphor/algorithm": "^1.1.2",
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/messaging": "^1.2.2",
-            "@phosphor/signaling": "^1.2.2",
-            "@phosphor/widgets": "^1.6.0",
-            "lodash.escape": "^4.0.1",
-            "marked": "0.5.1"
-          },
-          "dependencies": {
-            "@jupyterlab/services": {
-              "version": "4.0.0-alpha.6",
-              "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.0.0-alpha.6.tgz",
-              "integrity": "sha512-veLHmuPFMVt4ByLAks3+7GVpk3zMcBmBfUt2RiswHfeBhzGgSVEOq/Tovt59DUQ9wgBsYCUsrbBjrHHr/0jyZg==",
-              "dev": true,
-              "requires": {
-                "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-                "@jupyterlab/observables": "^2.2.0-alpha.6",
-                "@phosphor/algorithm": "^1.1.2",
-                "@phosphor/coreutils": "^1.3.0",
-                "@phosphor/disposable": "^1.1.2",
-                "@phosphor/signaling": "^1.2.2",
-                "node-fetch": "~2.2.0",
-                "ws": "~6.0.0"
-              }
-            }
-          }
-        },
-        "@jupyterlab/rendermime-interfaces": {
-          "version": "1.3.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.3.0-alpha.6.tgz",
-          "integrity": "sha512-4braKQb3pVWQ+QeGfvpGjMtKsXOkevRvnUTb3AICGrnmG4cGEC9JN3QiSihWgELguM6Wu08XUzCWo6MlH31Y7w==",
-          "dev": true,
-          "requires": {
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/widgets": "^1.6.0"
-          }
-        },
-        "@types/react": {
-          "version": "16.8.13",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.13.tgz",
-          "integrity": "sha512-otJ4ntMuHGrvm67CdDJMAls4WqotmAmW0g3HmWi9LCjSWXrxoXY/nHXrtmMfvPEEmGFNm6NdgMsJmnfH820Qaw==",
-          "dev": true,
-          "requires": {
-            "@types/prop-types": "*",
-            "csstype": "^2.2.0"
-          }
-        },
         "ajv": {
           "version": "5.5.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -1121,68 +799,6 @@
             "fast-deep-equal": "^1.0.0",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.3.0"
-          },
-          "dependencies": {
-            "fast-deep-equal": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-              "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-              "dev": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-              "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-              "dev": true
-            }
-          }
-        },
-        "codemirror": {
-          "version": "5.42.2",
-          "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.42.2.tgz",
-          "integrity": "sha512-Tkv6im39VuhduFMsDA3MlXcC/kKas3Z0PI1/8N88QvFQbtOeiiwnfFJE4juGyC8/a4sb1BSxQlzsil8XLQdxRw==",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        },
-        "marked": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.5.1.tgz",
-          "integrity": "sha512-iUkBZegCZou4AdwbKTwSW/lNDcz5OuRSl3qdcl31Ia0B2QPG0Jn+tKblh/9/eP9/6+4h27vpoh8wel/vQOV0vw==",
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.1.tgz",
-          "integrity": "sha512-ObXBpNCD3A/vYQiQtEWl7DuqjAXjfptYFuGHLdPl5U19/6kJuZV+8uMHLrkj3wJrJoyfg4nhgyFixZdaZoAiEQ==",
-          "dev": true
-        },
-        "react": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-          "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.13.6"
-          }
-        },
-        "react-dom": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-          "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.13.6"
           }
         }
       }
@@ -1197,9 +813,9 @@
       }
     },
     "@jupyter-widgets/schema": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@jupyter-widgets/schema/-/schema-0.3.7.tgz",
-      "integrity": "sha512-KgIxq0DpESBvRFzLAoH2QEZNtBElLSJE4IPzaS5mgt7Upg1d/0N5jaKdl5ZxSwN/4LuPkFDT38jPwdR0dzOXCA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jupyter-widgets/schema/-/schema-0.3.6.tgz",
+      "integrity": "sha512-h3StW54RlQnL4YzNhRi4MvQnHlWFalHa0rYMQgcXN264abe5GWa9vfmynztXy+hcwPcUObsweHjEzTkNIfM8sw==",
       "dev": true
     },
     "@jupyterlab/application": {
@@ -1411,173 +1027,6 @@
         "@phosphor/signaling": "^1.2.2"
       }
     },
-    "@jupyterlab/statusbar": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-ARKOMOS6F35z3zPlxwju/3eWIuivH9js3fOlzzM5Jbj0Gag9FO/2SzlPSIcHTVKXlqxBBYkzq05UaC0Na7h/uw==",
-      "dev": true,
-      "requires": {
-        "@jupyterlab/apputils": "^1.0.0-alpha.6",
-        "@jupyterlab/codeeditor": "^1.0.0-alpha.6",
-        "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-        "@jupyterlab/services": "^4.0.0-alpha.6",
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/messaging": "^1.2.2",
-        "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.6.0",
-        "react": "~16.8.4",
-        "typestyle": "^2.0.1"
-      },
-      "dependencies": {
-        "@jupyterlab/apputils": {
-          "version": "1.0.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.0.0-alpha.6.tgz",
-          "integrity": "sha512-Ir7LHfXl/kcFiXmGWGayaMXShyi8WkLa9pRAUJYuRYcGbhJwvpKwGpaakrFr021UGFWJtem8mTTSAJ7s3OyOlA==",
-          "dev": true,
-          "requires": {
-            "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-            "@jupyterlab/services": "^4.0.0-alpha.6",
-            "@jupyterlab/ui-components": "^1.0.0-alpha.6",
-            "@phosphor/algorithm": "^1.1.2",
-            "@phosphor/commands": "^1.6.1",
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/disposable": "^1.1.2",
-            "@phosphor/domutils": "^1.1.2",
-            "@phosphor/messaging": "^1.2.2",
-            "@phosphor/properties": "^1.1.2",
-            "@phosphor/signaling": "^1.2.2",
-            "@phosphor/virtualdom": "^1.1.2",
-            "@phosphor/widgets": "^1.6.0",
-            "@types/react": "~16.8.8",
-            "react": "~16.8.4",
-            "react-dom": "~16.8.4",
-            "sanitize-html": "~1.18.2"
-          }
-        },
-        "@jupyterlab/codeeditor": {
-          "version": "1.0.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.0.0-alpha.6.tgz",
-          "integrity": "sha512-6Y1m7s/CAEni/C+cWHToIbAsuCzahgBCtEqhrtnoHBD/LQvZ45RYuvIfhCAyEmT/ObQr1EN9gfmBkVnqzvnjXQ==",
-          "dev": true,
-          "requires": {
-            "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-            "@jupyterlab/observables": "^2.2.0-alpha.6",
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/disposable": "^1.1.2",
-            "@phosphor/dragdrop": "^1.3.0",
-            "@phosphor/messaging": "^1.2.2",
-            "@phosphor/signaling": "^1.2.2",
-            "@phosphor/widgets": "^1.6.0"
-          }
-        },
-        "@jupyterlab/coreutils": {
-          "version": "3.0.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.0.0-alpha.6.tgz",
-          "integrity": "sha512-t3Lp9iFRjzTsc573+KGKStE/YvkUbKQ2+7FF0hz9fDkeWp6+ZNCHWD97eudo6V+I/g5zRgO8eqgbjeKhGyv/KA==",
-          "dev": true,
-          "requires": {
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/disposable": "^1.1.2",
-            "@phosphor/signaling": "^1.2.2",
-            "ajv": "^6.5.5",
-            "comment-json": "^1.1.3",
-            "minimist": "~1.2.0",
-            "moment": "~2.21.0",
-            "path-posix": "~1.0.0",
-            "url-parse": "~1.4.3"
-          }
-        },
-        "@jupyterlab/observables": {
-          "version": "2.2.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.2.0-alpha.6.tgz",
-          "integrity": "sha512-u93u/knpD3Lijye3jlu3xfyZotcreFhQloZ+1iKRSXmDFwNvkjJqwTd9ibq9v1fcfGDcy+AiE50+7RqDxQ9YAQ==",
-          "dev": true,
-          "requires": {
-            "@phosphor/algorithm": "^1.1.2",
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/disposable": "^1.1.2",
-            "@phosphor/messaging": "^1.2.2",
-            "@phosphor/signaling": "^1.2.2"
-          }
-        },
-        "@jupyterlab/services": {
-          "version": "4.0.0-alpha.6",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.0.0-alpha.6.tgz",
-          "integrity": "sha512-veLHmuPFMVt4ByLAks3+7GVpk3zMcBmBfUt2RiswHfeBhzGgSVEOq/Tovt59DUQ9wgBsYCUsrbBjrHHr/0jyZg==",
-          "dev": true,
-          "requires": {
-            "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-            "@jupyterlab/observables": "^2.2.0-alpha.6",
-            "@phosphor/algorithm": "^1.1.2",
-            "@phosphor/coreutils": "^1.3.0",
-            "@phosphor/disposable": "^1.1.2",
-            "@phosphor/signaling": "^1.2.2",
-            "node-fetch": "~2.2.0",
-            "ws": "~6.0.0"
-          }
-        },
-        "@types/react": {
-          "version": "16.8.13",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.13.tgz",
-          "integrity": "sha512-otJ4ntMuHGrvm67CdDJMAls4WqotmAmW0g3HmWi9LCjSWXrxoXY/nHXrtmMfvPEEmGFNm6NdgMsJmnfH820Qaw==",
-          "dev": true,
-          "requires": {
-            "@types/prop-types": "*",
-            "csstype": "^2.2.0"
-          }
-        },
-        "ajv": {
-          "version": "6.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.1.tgz",
-          "integrity": "sha512-ObXBpNCD3A/vYQiQtEWl7DuqjAXjfptYFuGHLdPl5U19/6kJuZV+8uMHLrkj3wJrJoyfg4nhgyFixZdaZoAiEQ==",
-          "dev": true
-        },
-        "react": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-          "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.13.6"
-          }
-        },
-        "react-dom": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-          "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.13.6"
-          }
-        }
-      }
-    },
     "@jupyterlab/theme-light-extension": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@jupyterlab/theme-light-extension/-/theme-light-extension-0.19.1.tgz",
@@ -1587,32 +1036,6 @@
         "@jupyterlab/application": "^0.19.1",
         "@jupyterlab/apputils": "^0.19.1",
         "font-awesome": "~4.7.0"
-      }
-    },
-    "@jupyterlab/ui-components": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-XTrN8HcwPQHBE4PBkxPZ9GI8d528RQRWekXFippkBObqrf5GXnp2QBQ325jwIG/rFswePMGWpsDWZ1+ZQOEl+w==",
-      "dev": true,
-      "requires": {
-        "@blueprintjs/core": "^3.9.0",
-        "@blueprintjs/icons": "^3.3.0",
-        "@blueprintjs/select": "^3.3.0",
-        "react": "~16.8.4"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-          "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.13.6"
-          }
-        }
       }
     },
     "@phosphor/algorithm": {
@@ -1754,12 +1177,6 @@
         "@types/jquery": "*",
         "@types/underscore": "*"
       }
-    },
-    "@types/dom4": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/dom4/-/dom4-2.0.1.tgz",
-      "integrity": "sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA==",
-      "dev": true
     },
     "@types/jquery": {
       "version": "3.3.29",
@@ -2218,12 +1635,6 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
-    "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-      "dev": true
-    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -2634,12 +2045,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
-      "dev": true
-    },
     "cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -2894,16 +2299,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "create-react-context": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
-      "integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
-      "dev": true,
-      "requires": {
-        "fbjs": "^0.8.0",
-        "gud": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -3208,15 +2603,6 @@
         "randombytes": "^2.0.0"
       }
     },
-    "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2"
-      }
-    },
     "dom-serializer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
@@ -3226,12 +2612,6 @@
         "domelementtype": "^1.3.0",
         "entities": "^1.1.1"
       }
-    },
-    "dom4": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/dom4/-/dom4-2.1.4.tgz",
-      "integrity": "sha512-7NNKNViuZYu4GaZMUsSbsV6MFsT/ZpYNKP1NT4YIUgAvwPR8ODuvQEZZ7vRC1u5Y4dHwQ7je/UNOlRRWkaCyvw==",
-      "dev": true
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -3628,9 +3008,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -3806,12 +3186,6 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
-    },
-    "free-style": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/free-style/-/free-style-2.5.1.tgz",
-      "integrity": "sha512-X7dtUSTrlS1KRQBtiQ618NWIRDdRgD91IeajKCSh0fgTqArSixv+n3ea6F/OSvrvg14tPLR+yCq2s+O602+pRw==",
-      "dev": true
     },
     "from2": {
       "version": "2.3.0",
@@ -4131,12 +3505,6 @@
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
-    },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
       "dev": true
     },
     "has": {
@@ -4772,12 +4140,6 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
-    "lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
-      "dev": true
-    },
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
@@ -5285,12 +4647,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
-    "normalize.css": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
-      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
-      "dev": true
-    },
     "npm-bundled": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
@@ -5638,12 +4994,6 @@
       "requires": {
         "find-up": "^3.0.0"
       }
-    },
-    "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==",
-      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -6022,38 +5372,6 @@
       "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==",
       "dev": true
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
-    },
-    "react-popper": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.3.tgz",
-      "integrity": "sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "create-react-context": "<=0.2.2",
-        "popper.js": "^1.14.4",
-        "prop-types": "^15.6.1",
-        "typed-styles": "^0.0.7",
-        "warning": "^4.0.2"
-      }
-    },
-    "react-transition-group": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-      "dev": true,
-      "requires": {
-        "dom-helpers": "^3.4.0",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
     "readable-stream": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
@@ -6241,12 +5559,6 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "dev": true
-    },
     "resolve": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
@@ -6365,16 +5677,6 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true,
       "optional": true
-    },
-    "scheduler": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "schema-utils": {
       "version": "1.0.0",
@@ -7050,27 +6352,11 @@
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
-    "typed-styles": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
-      "dev": true
-    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "typestyle": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/typestyle/-/typestyle-2.0.1.tgz",
-      "integrity": "sha512-3Mv5ZZbYJ3y3G6rX3iRLrgYibAlafK2nsc9VlTsYcEaK8w+9vtNDx0T2TJsznI5FIh+WoBnjJ5F0/26WaGRxXQ==",
-      "dev": true,
-      "requires": {
-        "csstype": "^2.4.0",
-        "free-style": "2.5.1"
-      }
     },
     "ua-parser-js": {
       "version": "0.7.19",
@@ -7308,15 +6594,6 @@
       "dev": true,
       "requires": {
         "indexof": "0.0.1"
-      }
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {
@@ -7572,15 +6849,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "ws": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.0.0.tgz",
-      "integrity": "sha512-c2UlYcAZp1VS8AORtpq6y4RJIkJ9dQz18W32SpR/qXGfLDZ2jU4y4wKvvZwqbi7U6gxFQTeE+urMbXU/tsDy4w==",
-      "dev": true,
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-env": "^7.0.0-beta.55",
     "@jupyter-widgets/base": "^1.2.2",
     "@jupyter-widgets/controls": "^1.4.2",
-    "@jupyter-widgets/html-manager": "^0.16.0",
+    "@jupyter-widgets/html-manager": "^0.15.2",
     "@jupyter-widgets/output": "^1.1.2",
     "@jupyterlab/codemirror": "^0.19.1",
     "@jupyterlab/mathjax2": "^0.7.1",


### PR DESCRIPTION
`html-manager` 0.16, which was added into package.json in #28 is a backward incompatible release.

Updating to this version will require more changes than just updating the package.json.