### PR TITLE
add missing %matplotlib inline to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ For example, see the following code cell:
    <script src="https://unpkg.com/thebelab@0.4.0/lib/index.js"></script>
 
    <pre data-executable="true" data-language="python">
+   %matplotlib inline
    import numpy as np
    import matplotlib.pyplot as plt
    plt.ion()


### PR DESCRIPTION
this shouldn't be required (ipykernel or matplotlib bug), but it is. Closes #158 