### PR TITLE
codemirror uses merged options

### DIFF
--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -255,7 +255,7 @@ function renderCell(element, options) {
     },
   };
   let codeMirrorConfig = Object.assign(
-    options.codeMirrorconfig || {},
+    mergedOptions.codeMirrorconfig || {},
     required
   );
   let cm = new CodeMirror($cm_element[0], codeMirrorConfig);


### PR DESCRIPTION
Use merged options for codemirror to enable user extend the required options. Closes: #168. Seems it Closes: #126 as well. 