### PR TITLE
python mode without number

### DIFF
--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -246,7 +246,7 @@ function renderCell(element, options) {
   $cell.append(theDiv);
   Widget.attach(outputArea, theDiv);
 
-  const mode = $element.data("language") || "python3";
+  const mode = $element.data("language") || "python";
   const required = {
     value: source,
     mode: mode,


### PR DESCRIPTION
Skip number to set the mode of the language in Codemirror. Closes #169, Closes #96 