### PR TITLE
add kernelName to kernelOptions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ A full config script with defaults:
   // Options for requesting a kernel from the notebook server
   kernelOptions: {
     name: "python3",
+    kernelName: "python3",
     // notebook server configuration; not needed with binder
     // serverSettings: {
-    //       "baseUrl": "http://127.0.0.1:8888",
+    //      "baseUrl": "http://127.0.0.1:8888",
     //      "token": "test-secret"
     //    }
   },


### PR DESCRIPTION
The current config doc having only `kernelOptions.name` is a bit confusing. It lets user think that by simply change the name to something like R will enable a R kernel (at least that is what I thought). To run other language, I found that `kernelOptions.kernelName` is what I needed. Including this in the doc I believe will help a lot of people.

The kernelName is passed to @jupyterlab/services and [here](https://github.com/jupyterlab/jupyterlab/blob/37c7a647a1344712c8cf80414db73809f486e766/packages/services/src/session/session.ts#L381) is where kernelName is defined.