### PR TITLE
Loads CodeMirror Themes

### DIFF
--- a/docs/howto/cm_customize.rst
+++ b/docs/howto/cm_customize.rst
@@ -17,7 +17,7 @@ You can edit all of these attributes in a cell with the following thebelab confi
    </script>
 
 You can use any of `the available CodeMirror configurations <https://codemirror.net/doc/manual.html#config>`_.
-For example, the following configuration changes the CodeMirror theme:
+For example, the following configuration changes the `CodeMirror theme <https://codemirror.net/theme/>`_:
 
 .. code:: html
 

--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -255,8 +255,22 @@ function renderCell(element, options) {
       "Shift-Enter": execute,
     },
   };
+
+  // Gets CodeMirror config if it exists
+  let codeMirrorOptions = {};
+  if ('binderOptions' in mergedOptions) {
+    if ('codeMirrorConfig' in mergedOptions.binderOptions) {
+      codeMirrorOptions = mergedOptions.binderOptions.codeMirrorConfig
+    }
+  }
+
+  // Dynamically loads CSS for a given theme
+  if ('theme' in codeMirrorOptions) {
+    require(`codemirror/theme/${codeMirrorOptions.theme}.css`);
+  }
+
   let codeMirrorConfig = Object.assign(
-    mergedOptions.codeMirrorconfig || {},
+    codeMirrorOptions || {},
     required
   );
   let cm = new CodeMirror($cm_element[0], codeMirrorConfig);


### PR DESCRIPTION
Resolves #190 

Fixes our theme lookup. It also loads theme style as that isn't initially loaded. It only loads the theme that is given in the configuration.