### PR TITLE
adding events docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,37 +9,7 @@ jobs:
       - checkout
       - node/install-packages
 
-  docs:
-    docker:
-      - image: circleci/python:3.7-stretch
-    steps:
-      # Get our data and merge with upstream
-      - run: sudo apt-get update
-      - checkout
-
-      - restore_cache:
-          keys:
-            - cache-pip
-
-      - run: |
-          pip install --user -r docs/doc-requirements.txt
-      - save_cache:
-          key: cache-pip
-          paths:
-            - ~/.cache/pip
-
-      # Build the docs
-      - run:
-          name: Build docs to store
-          command: |
-            sphinx-build -b html docs/ docs/_build/html
-
-      - store_artifacts:
-          path: docs/_build/html/
-          destination: html
-
 workflows:
     build-and-test:
       jobs:
         - build-and-test
-        - docs

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -1,0 +1,27 @@
+Event hooks in Thebelab
+=======================
+
+When Thebelab is launched (with ``thebelab.bootstrap``), it will emit a series
+of events corresponding to the state of the launch process. You can plug into
+these events to control the behavior on your page.
+
+To do so, use the ``status`` event within Thebelab, like so:
+
+.. code-block:: javascript
+
+       thebelab.on("status", function (evt, data) {
+        console.log("Status changed:", data.status, data.message);
+    });
+
+In the above code, the ``data`` object contains a collection of information about
+Thebelab, and ``data.status`` will reflect the current state of Thebelab. This will
+cycle between these states:
+
+* ``building``
+* ``built``
+* ``launching``
+* ``ready``
+
+These events can be used to do things like running code once the Jupyter Kernels is
+ready, or manipulating the page DOM before launching Thebelab to result in certain
+behavior (e.g. a "loading status" button).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,6 +97,7 @@ Horizon 2020 European Research Infrastructure project (676541).
 
    start
    configure
+   events
    config_reference
    howto/initialize_cells
    minimal_example


### PR DESCRIPTION
This adds a page to discuss events in Thebelab, and how to hook into them.

Also removes CircleCI building for docs so that we can use readthedocs for PR previews